### PR TITLE
Improve parsing of global npm packages

### DIFF
--- a/npm-g-no-sudo.sh
+++ b/npm-g-no-sudo.sh
@@ -47,8 +47,7 @@ fi
 #Get a list of global packages (not deps)
 #except for the npm package
 #save in a temporary file.
-npm -g list -depth=0 | awk '!/npm/ {print $2}' >$to_reinstall
-
+npm -g list --depth=0 --parseable --long | cut -d: -f2 | grep -v '^npm@\|^$' >$to_reinstall
 
 if [ 1 = ${VERBOSE} ];	then
 	printf "\nRemoving existing packages temporarily - you might need your sudo password\n\n"


### PR DESCRIPTION
- Rely on npm --parseable output
- Use cut instead of awk
- grep (inverted) for exact match of npm (otherwise you might filter packages that contain npm word in them)
- clean empty lines with grep as well
