### PR TITLE
Handle empty NODE_PATH

### DIFF
--- a/npm-g-nosudo.sh
+++ b/npm-g-nosudo.sh
@@ -113,7 +113,7 @@ fi
 
 envfix='
 export NPM_PACKAGES="%s"
-export NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"
+export NODE_PATH="$NPM_PACKAGES/lib/node_modules${NODE_PATH:+:$NODE_PATH}"
 export PATH="$NPM_PACKAGES/bin:$PATH"
 # Unset manpath so we can inherit from /etc/manpath via the `manpath`
 # command


### PR DESCRIPTION
If NODE_PATH is empty/uninitialized, don't leave a dangling colon hanging off the end of the newly-assigned value.