### PR TITLE
Change default behaviour for prompt to fix environment.

### DIFF
--- a/npm-g-nosudo.sh
+++ b/npm-g-nosudo.sh
@@ -143,7 +143,7 @@ read -p "Do you wish to update your .bashrc/.zshrc file(s) with the paths and ma
 case $yn in
     [Yy]* ) fix_env;;
     [Nn]* ) echo_env;;
-    * ) echo "Please answer 'y' or 'n'.";;
+    * ) printf "\nInvalid choice\n"; echo_env;;
 esac
 
 rm $to_reinstall


### PR DESCRIPTION
Running this script with wget piping to sh means that it doesn't
work interactively.  In this case make the default behaviour to
echo out the required environment changes when the user is
prompted to fix their env at the end of the script.
Should resolve problems like issue #20