### PR TITLE
Fix invalid directory

### DIFF
--- a/npm-g-nosudo.sh
+++ b/npm-g-nosudo.sh
@@ -95,7 +95,7 @@ if [ 1 = ${VERBOSE} ];  then
 fi
 
 me=`whoami`
-sudo chown -R $me ~/.npm
+sudo chown -R $me $npmdir
 
 if [ 1 = ${VERBOSE} ];  then
     printf "\nReinstall packages\n\n"


### PR DESCRIPTION
By default we create `~/.npm-packages` and trying to chown (not existing) `~/.npm` will crash the script.