### PR TITLE
No need to call sudo inside the script.

### DIFF
--- a/npm-g-nosudo.sh
+++ b/npm-g-nosudo.sh
@@ -66,7 +66,7 @@ fi
 #remove the newlines
 #and pass to npm uninstall
 
-uninstall='sudo npm -g uninstall'
+uninstall='npm -g uninstall'
 if [ 1 = ${DEBUG} ];    then
     printf "Won't uninstall\n\n"
     uninstall='echo'
@@ -104,7 +104,7 @@ if [ 1 = ${VERBOSE} ];  then
 fi
 
 me=`whoami`
-sudo chown -R $me $npmdir
+chown -R $me $npmdir
 
 if [ 1 = ${VERBOSE} ];  then
     printf "\nReinstall packages\n\n"


### PR DESCRIPTION
In the default case (`npm config set prefix "${HOME}/.npm-packages"`), the user will not need to use sudo at all, and in a case where the user need the sudo permissions, he can just `sudo ./npm-g-nosudo.sh`.

Made this because I'm in a computer where I don't have sudo permissions.